### PR TITLE
[FIX] Sets.find() returning undefined for valid IDs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,7 +28,7 @@ export class Client {
 
     if (params) {
       params.map(param => {
-        if (resource === 'sets' && param.name === 'id') {
+        if (param.name === 'id') {
           url = `/${param.value}`;
         }
       });

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,7 +5,7 @@ import { IQuery } from './interfaces/query';
 export class Client {
   static apiUrl: string = `${PokemonTCG.API_URL}/v${PokemonTCG.version}`;
 
-  static get(resource: string, params?: IQuery[]): Promise<any> {
+  static get(resource: string, params?: IQuery[] | string): Promise<any> {
     let url: string = `${this.apiUrl}/${resource}`;
     let config: axios.AxiosRequestConfig = {
       headers: {
@@ -13,28 +13,13 @@ export class Client {
       }
     };
 
-    // This is needed because the /sets endpoint doesn't take
-    // an id as a parameter so we need to append it to the url
-    url += this.checkForId(resource, params);
+    if(typeof params === 'string') url += `/${params}`;
+    else url += `?${this.paramsToQuery(params)}`;
 
-    return axios.default.get<any>(`${url}?${this.paramsToQuery(params)}`, config)
+    return axios.default.get<any>(url, config)
       .then(response => {
         return response.data[Object.keys(response.data)[0]];
       })
-  }
-
-  private static checkForId(resource: string, params?: IQuery[]): string {
-    let url: string = '';
-
-    if (params) {
-      params.map(param => {
-        if (param.name === 'id') {
-          url = `/${param.value}`;
-        }
-      });
-    }
-
-    return url;
   }
 
   private static paramsToQuery(params?: IQuery[]): string {

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -5,33 +5,25 @@ import { IQuery } from './interfaces/query';
 import { AxiosResponse } from 'axios';
 
 export class QueryBuilder {
-  static all<T extends Card | Set>(type: (new() => T)): Promise<T[]> {
-    let t = new type();
-    let params: IQuery[] = [{
-      name: 'pageSize',
-      value: 1000
-    }];
+    static all<T extends Card | Set>(type: (new () => T)): Promise<T[]> {
+        let t = new type();
+        let params: IQuery[] = [{
+            name: 'pageSize',
+            value: 1000
+        }];
 
-    return this.returnResponse(t.resource(), params);
-  }
+        return Client.get(t.resource(), params).catch(error => console.error(error));
+    }
 
-  static find<T extends Card | Set>(type: (new() => T), id: string): Promise<T> {
-    let t = new type();
-    let params: IQuery[] = [{
-      name: 'id',
-      value: id
-    }];
+    static find<T extends Card | Set>(type: (new () => T), id: string): Promise<T> {
+        let t = new type();
 
-    return this.returnResponse(t.resource(), params);
-  }
+        return Client.get(t.resource(), id).catch(error => console.error(error));
+    }
 
-  static where<T extends Card | Set>(type: (new() => T), params: IQuery[]): Promise<T[]> {
-    let t = new type();
+    static where<T extends Card | Set>(type: (new () => T), params: IQuery[]): Promise<T[]> {
+        let t = new type();
 
-    return this.returnResponse(t.resource(), params);
-  }
-
-  private static returnResponse(resource: string, params: IQuery[]): Promise<any> {
-    return Client.get(resource, params).catch(error => console.error(error));
-  }
+        return Client.get(t.resource(), params).catch(error => console.error(error));
+    }
 }

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -32,10 +32,6 @@ export class QueryBuilder {
   }
 
   private static returnResponse(resource: string, params: IQuery[]): Promise<any> {
-    return Client.get(resource, params)
-      .then(response => {
-        return response;
-      })
-      .catch(error => console.error(error));
+    return Client.get(resource, params).catch(error => console.error(error));
   }
 }

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -22,7 +22,7 @@ export class QueryBuilder {
       value: id
     }];
 
-    return this.returnResponse(t.resource(), params, true);
+    return this.returnResponse(t.resource(), params);
   }
 
   static where<T extends Card | Set>(type: (new() => T), params: IQuery[]): Promise<T[]> {
@@ -31,13 +31,9 @@ export class QueryBuilder {
     return this.returnResponse(t.resource(), params);
   }
 
-  private static returnResponse(resource: string, params: IQuery[], single?: boolean): Promise<any> {
+  private static returnResponse(resource: string, params: IQuery[]): Promise<any> {
     return Client.get(resource, params)
       .then(response => {
-        if (single) {
-          return response[0];
-        }
-
         return response;
       })
       .catch(error => console.error(error));


### PR DESCRIPTION
The original issue here was that the `Sets.find()` method was returning undefined.

I tracked this down to the `returnResponse` method, where it was trying to access the response[0] index if `single` was true. However because `checkForId` correctly adds the `/sets/:id` path parameter to return an object instead of an array, this double-handling was causing the error.

I looked a bit further into why the `single` option was there and realised that the `/cards/:id` endpoint _wasn't_ being utilised by find, when it could be. By allowing the `checkForId` function to work for both cards and sets, there's no need for the `single` option at all anymore as far as I can tell.