### PR TITLE
fix(5): Cant search for terms containing ampersand

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,7 +27,7 @@ export class Client {
 
     if (params) {
       params.map((q: IQuery) => {
-        query += `${q.name}=${encodeURI(q.value.toString())}`.concat('&');
+        query += `${q.name}=${encodeURIComponent(q.value.toString())}`.concat('&');
       });
     }
 


### PR DESCRIPTION
Fixes #5 

`encodeURI` does not replace the `&` character with `%26`
encodeURIComponent` does, and is the appropriate function for this use-case