### PR TITLE
add regulation mark and make rarity nullable

### DIFF
--- a/src/interfaces/card.ts
+++ b/src/interfaces/card.ts
@@ -32,9 +32,10 @@ export interface Card {
     set: Set;
     number: string;
     artist?: string;
-    rarity: Rarity;
+    rarity?: Rarity;
     flavorText?: string;
     nationalPokedexNumbers?: number[];
+    regulationMark?: string;
     legalities: ILegality;
     images: CardImage;
     tcgplayer?: TCGPlayer;


### PR DESCRIPTION
This PR adds `regulationMark` (currently exists on master) and makes `rarity` nullable on the Card interface.
Rarity doesn't exist in the API for certain cards in weird sets such as southern islands and pokemon rumble,