### PR TITLE
make rarity nullable

### DIFF
--- a/src/interfaces/card.ts
+++ b/src/interfaces/card.ts
@@ -29,7 +29,7 @@ export interface ICard {
   set: ISet;
   number: string;
   artist?: string;
-  rarity: string;
+  rarity?: string;
   flavorText?: string;
   nationalPokedexNumbers?: number[];
   legalities: ILegality;


### PR DESCRIPTION
This PR makes `rarity` nullable on the Card interface.
Rarity doesn't exist in the API for certain cards in weird sets such as southern islands and pokemon rumble,